### PR TITLE
Fix CF sidecar environment handling

### DIFF
--- a/deployments/cloud-foundry/go/manifest.yaml
+++ b/deployments/cloud-foundry/go/manifest.yaml
@@ -23,42 +23,16 @@ applications:
       - name: crypto-broker-server
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-crypto-broker-server"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_METRICS_EXPORTER: "otlpgrpc"
-          OTEL_METRICS_INTERVAL: "10s"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "localhost:4317"
-        command: 'CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
+        command: 'OTEL_SERVICE_NAME=test-crypto-broker-server OTEL_LOGS_EXPORTER=otlpgrpc OTEL_METRICS_EXPORTER=otlpgrpc OTEL_METRICS_INTERVAL=10s OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
       - name: crypto-broker-client-profile-default
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-app-go-default-profile"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "localhost:4317"
-        command: './go-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-go-default-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 ./go-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
       - name: crypto-broker-client-profile-fips-baseline
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-app-go-fips-baseline-profile"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "localhost:4317"
-        command: './go-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-go-fips-baseline-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 ./go-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
       - name: crypto-broker-client-profile-fips-strict
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-app-go-fips-strict-profile"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "localhost:4317"
-        command: './go-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-go-fips-strict-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 ./go-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'

--- a/deployments/cloud-foundry/go/manifest.yaml
+++ b/deployments/cloud-foundry/go/manifest.yaml
@@ -23,16 +23,16 @@ applications:
       - name: crypto-broker-server
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-crypto-broker-server OTEL_LOGS_EXPORTER=otlpgrpc OTEL_METRICS_EXPORTER=otlpgrpc OTEL_METRICS_INTERVAL=10s OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
+        command: 'OTEL_SERVICE_NAME=test-crypto-broker-server OTEL_METRICS_EXPORTER=otlpgrpc OTEL_METRICS_INTERVAL=10s CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
       - name: crypto-broker-client-profile-default
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-app-go-default-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 ./go-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-go-default-profile ./go-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
       - name: crypto-broker-client-profile-fips-baseline
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-app-go-fips-baseline-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 ./go-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-go-fips-128bit-profile ./go-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
       - name: crypto-broker-client-profile-fips-strict
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-app-go-fips-strict-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 ./go-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-go-fips-256bit-profile ./go-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'

--- a/deployments/cloud-foundry/js/manifest.yaml
+++ b/deployments/cloud-foundry/js/manifest.yaml
@@ -24,16 +24,16 @@ applications:
       - name: crypto-broker-server
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-crypto-broker-server OTEL_LOGS_EXPORTER=otlpgrpc OTEL_METRICS_EXPORTER=otlpgrpc OTEL_METRICS_INTERVAL=10s OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
+        command: 'OTEL_SERVICE_NAME=test-crypto-broker-server OTEL_METRICS_EXPORTER=otlpgrpc OTEL_METRICS_INTERVAL=10s CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
       - name: crypto-broker-client-profile-default
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-app-js-default-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 ./js-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-js-default-profile ./js-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
       - name: crypto-broker-client-profile-fips-baseline
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-app-js-fips-baseline OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 ./js-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-js-fips-128bit-profile ./js-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
       - name: crypto-broker-client-profile-fips-strict
         health-check-type: process
         process_types: [web]
-        command: 'OTEL_SERVICE_NAME=test-app-js-fips-strict OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 ./js-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-js-fips-256bit-profile ./js-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'

--- a/deployments/cloud-foundry/js/manifest.yaml
+++ b/deployments/cloud-foundry/js/manifest.yaml
@@ -24,42 +24,16 @@ applications:
       - name: crypto-broker-server
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-crypto-broker-server"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_METRICS_EXPORTER: "otlpgrpc"
-          OTEL_METRICS_INTERVAL: "10s"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "localhost:4317"
-        command: 'CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
+        command: 'OTEL_SERVICE_NAME=test-crypto-broker-server OTEL_LOGS_EXPORTER=otlpgrpc OTEL_METRICS_EXPORTER=otlpgrpc OTEL_METRICS_INTERVAL=10s OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 CRYPTO_BROKER_PROFILES_DIR=$PWD ./cryptobroker-server'
       - name: crypto-broker-client-profile-default
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-app-js-default-profile"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4317"
-        command: './js-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-js-default-profile OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 ./js-client-cli --loop 600 sign --profile=Default --csr=certificates/test-csr/csr-rsa-2048.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp384r1.pem --caKey=certificates/test-ca/test-CA-nist-secp384r1.pem'
       - name: crypto-broker-client-profile-fips-baseline
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-app-js-fips-baseline"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4317"
-        command: './js-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-js-fips-baseline OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 ./js-client-cli --loop 700 sign --profile=FIPS-140-3-128bit --csr=certificates/test-csr/csr-rsa-8192.csr --caCert=certificates/test-ca/cert-test-CA-rsa-3072.pem --caKey=certificates/test-ca/test-CA-rsa-3072.pem'
       - name: crypto-broker-client-profile-fips-strict
         health-check-type: process
         process_types: [web]
-        env:
-          OTEL_SERVICE_NAME: "test-app-js-fips-strict"
-          OTEL_LOGS_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_EXPORTER: "otlpgrpc"
-          OTEL_TRACES_SAMPLER: "always_on"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4317"
-        command: './js-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'
+        command: 'OTEL_SERVICE_NAME=test-app-js-fips-strict OTEL_LOGS_EXPORTER=otlpgrpc OTEL_TRACES_EXPORTER=otlpgrpc OTEL_TRACES_SAMPLER=always_on OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 ./js-client-cli --loop 800 sign --profile=FIPS-140-3-256bit --csr=certificates/test-csr/csr-rsa-15380.csr --caCert=certificates/test-ca/cert-test-CA-nist-secp521r1.pem --caKey=certificates/test-ca/test-CA-nist-secp521r1.pem'


### PR DESCRIPTION
## Summary
- remove unsupported sidecar-level env blocks from the CF sample manifests
- inline sidecar-specific OpenTelemetry and server env vars in each sidecar command

## Why
Cloud Foundry sidecar manifest entries support command/process metadata, while app-level env is inherited as a shared baseline. Sidecar-specific env blocks are not applied, so per-sidecar OTEL settings such as service names must be supplied directly in the command.
