### PR TITLE
feat: Add AES-GCM fixtures

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -13,7 +13,7 @@ vars:
         cmd: "./crypto-broker-cli-js/bin/js-client-cli"
         env: ".env.cli-js"
 
-  COMMANDS: ["health", "hash", "sign"]
+  COMMANDS: ["health", "hash", "sign", "encrypt"]
   # Here are the Known-Answer-Tests for the following text (without quotes): "Welcome CryptoBroker"
   KAT:
     map: {
@@ -30,6 +30,19 @@ vars:
       KAT_SHA3_512:
         14894112f30f982c01e1de386ee9ca60bff70469d9fd249a5f9fbfc66a29c37c76b3fb15c294a6b6d3a1609fa59ca14194e2bc9da16610fa7f1a10dad38d628e,
       }
+  # Plaintext used for the AES-GCM encrypt/decrypt Known-Answer-Tests (without quotes): "Welcome CryptoBroker"
+  ENC_PLAINTEXT: "Welcome CryptoBroker"
+  # AES-GCM KAT fixtures: maps each encryption profile to its fixture file in the
+  # testing folder. Each fixture holds the hex-encoded KEY, NONCE, AAD and the
+  # expected CIPHERTEXT and TAG for the plaintext above (caller-managed rawKey flow).
+  ENC_KAT:
+    map:
+      FIPS-140-3-128bit:
+        fixture: testing/encryption/aes-128-gcm.env
+      FIPS-140-3-192bit:
+        fixture: testing/encryption/aes-192-gcm.env
+      FIPS-140-3-256bit:
+        fixture: testing/encryption/aes-256-gcm.env
   # Profiles, CSRs, and Issuer certificates for the SignCertificate tests in the Crypto Broker server
   PROFILES: [
     "Default",
@@ -243,7 +256,7 @@ tasks:
     requires:
       vars:
         - name: CMD
-          enum: ["health", "benchmark", "hash", "sign"]
+          enum: ["health", "benchmark", "hash", "sign", "encrypt"]
     vars:
       BRANCH: '{{.BRANCH | default "main"}}'
       OS: '{{.OS}}'
@@ -448,6 +461,80 @@ tasks:
           else
             echo "[✅] Hash value matches expected KAT"
           fi
+
+  # AES-GCM encrypt/decrypt tests from the clients
+  test-encrypt:
+    desc: "Iterate AES-GCM encrypt/decrypt round-trip tests over all clients"
+    internal: true
+    vars:
+      CLIENTS:
+        ref: .CLIENTS
+    cmds:
+      - for: { var: CLIENTS }
+        task: test-encrypt-KATs
+        vars:
+          CLIENT_PATH: '{{.ITEM.cmd}}'
+          CLIENT_ENV: '{{.ITEM.env}}'
+
+  test-encrypt-KATs:
+    desc: "Iterate over all AES-GCM KATs: encrypt (assert ciphertext/tag) then decrypt (assert round-trip)"
+    internal: true
+    silent: true
+    vars:
+      ENC_KAT:
+        ref: .ENC_KAT
+    cmds:
+      - for: { var: ENC_KAT }
+        cmd:
+          |
+          set -e
+          echo "[INFO] Test AES-GCM with profile {{.KEY}}"
+
+          set -a
+          source {{.CLIENT_ENV}}
+          source {{.ITEM.fixture}}
+          set +a
+
+          # Preserve the expected known-answer values before invoking the client
+          EXPECTED_CIPHERTEXT="$CIPHERTEXT"
+          EXPECTED_TAG="$TAG"
+
+          # --- Encrypt: assert ciphertext and tag match the known-answer test ---
+          ENC_RESPONSE=$({{.CLIENT_PATH}} encrypt \
+            --profile={{.KEY}} \
+            --keySource=raw \
+            --key="$KEY" \
+            --nonce="$NONCE" \
+            --aad="$AAD" \
+            "{{.ENC_PLAINTEXT}}")
+          ACTUAL_CIPHERTEXT=$(echo "$ENC_RESPONSE" | {{.GREP_CMD}} -oP '"ciphertext":\s?"\K[^"]+')
+          ACTUAL_TAG=$(echo "$ENC_RESPONSE" | {{.GREP_CMD}} -oP '"tag":\s?"\K[^"]+')
+
+          if [[ "$ACTUAL_CIPHERTEXT" != "$EXPECTED_CIPHERTEXT" ]]; then
+            echo "[❌] Ciphertext does not match expected KAT!"
+            exit 1
+          fi
+          if [[ "$ACTUAL_TAG" != "$EXPECTED_TAG" ]]; then
+            echo "[❌] Authentication tag does not match expected KAT!"
+            exit 1
+          fi
+          echo "[✅] Ciphertext and tag match expected KAT"
+
+          # --- Decrypt: assert the plaintext round-trips ---
+          DEC_RESPONSE=$({{.CLIENT_PATH}} decrypt \
+            --profile={{.KEY}} \
+            --keySource=raw \
+            --key="$KEY" \
+            --nonce="$NONCE" \
+            --aad="$AAD" \
+            --tag="$EXPECTED_TAG" \
+            "$EXPECTED_CIPHERTEXT")
+          ACTUAL_PLAINTEXT=$(echo "$DEC_RESPONSE" | {{.GREP_CMD}} -oP '"plaintext":\s?"\K[^"]+')
+          if [[ "$ACTUAL_PLAINTEXT" != "{{.ENC_PLAINTEXT}}" ]]; then
+            echo "[❌] Decrypted plaintext does not match original!"
+            exit 1
+          fi
+          echo "[✅] Decrypted plaintext matches original"
 
   # Sign certificate tests from the clients
   test-sign:

--- a/testing/encryption/aes-128-gcm.env
+++ b/testing/encryption/aes-128-gcm.env
@@ -1,0 +1,8 @@
+# AES-128-GCM known-answer test fixture
+# Plaintext (UTF-8, no quotes): Welcome CryptoBroker
+# All values are hex-encoded. Caller-managed (rawKey) flow.
+KEY=1619159426d9ac45243d3da9eed51899
+NONCE=08edd4dd6bfd0d69275ef2d0
+AAD=1af8fbdc64693a719f26baa04f0ce8be
+CIPHERTEXT=b613ddebb18ad870a69185f1b1015662e3a9a08a
+TAG=0e8a5ed855c3f96c2c35db398b714ffa

--- a/testing/encryption/aes-192-gcm.env
+++ b/testing/encryption/aes-192-gcm.env
@@ -1,0 +1,8 @@
+# AES-192-GCM known-answer test fixture
+# Plaintext (UTF-8, no quotes): Welcome CryptoBroker
+# All values are hex-encoded. Caller-managed (rawKey) flow.
+KEY=83a4dc40d7b3f75dcd0f9a7640ac4959ebe54d2b23ac036e
+NONCE=a0167ac07433cb6b0cb8e93a
+AAD=3ce44a50188bb27a6369b4f23fae8ba7
+CIPHERTEXT=a99cd0f1483805de0bf4ddd060a4e80709e992dc
+TAG=c3869e8390dd2e9690be966406b5e94f

--- a/testing/encryption/aes-256-gcm.env
+++ b/testing/encryption/aes-256-gcm.env
@@ -1,0 +1,8 @@
+# AES-256-GCM known-answer test fixture
+# Plaintext (UTF-8, no quotes): Welcome CryptoBroker
+# All values are hex-encoded. Caller-managed (rawKey) flow.
+KEY=67e1befda6538f162a308bb37b922441bed6e27039a26a48ad8e11c568c4cda0
+NONCE=a83f89b37c90f937b8df5011
+AAD=36e02c2a81c60eca849739d52dea95f7
+CIPHERTEXT=71416b876fb0d65c484ec20106af15a36454743b
+TAG=a77b42e960d89683140cae283a87466e

--- a/testing/profiles/Profiles.yaml
+++ b/testing/profiles/Profiles.yaml
@@ -175,6 +175,9 @@
   API:
     HashData:
       HashAlg: sha-256
+    EncryptData:
+      EncryptAlg: aes-gcm
+      KeySize: 128
     SignCertificate:
       SignAlg: rsa
       HashAlg: sha-256
@@ -210,6 +213,9 @@
   API:
     HashData:
       HashAlg: sha-384
+    EncryptData:
+      EncryptAlg: aes-gcm
+      KeySize: 192
     SignCertificate:
       SignAlg: ecdsa
       HashAlg: sha-384
@@ -245,6 +251,9 @@
   API:
     HashData:
       HashAlg: sha-512
+    EncryptData:
+      EncryptAlg: aes-gcm
+      KeySize: 256
     SignCertificate:
       SignAlg: ecdsa
       HashAlg: sha-512


### PR DESCRIPTION
## Description
Extend the three FIPS profiles with AES-GCM "EncryptData" APIs.
Add test fixtures for AES-GCM for 128, 192, and 256 bit key length.
Already include a possible CLI invocation in Taskfile for end-to-end tests.

## Type of change
- [ ] Bug fix
- [x] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
